### PR TITLE
OPS-200: fix goroutine leak by receiving done

### DIFF
--- a/gw.go
+++ b/gw.go
@@ -10,8 +10,9 @@ import (
 
 	"time"
 
-	"github.com/gorilla/websocket"
 	"log"
+
+	"github.com/gorilla/websocket"
 )
 
 type ErrorHandler func(error)
@@ -201,7 +202,7 @@ func (gw *Gateway) Handler(w http.ResponseWriter, r *http.Request) {
 	<-doneCh
 
 	err = natsConn.Conn.Close()
-	if err !=  nil {
+	if err != nil {
 		log.Println("unable to close nats connection", err)
 	}
 	err = wsConn.Close()
@@ -209,6 +210,7 @@ func (gw *Gateway) Handler(w http.ResponseWriter, r *http.Request) {
 		log.Println("unable to close ws connection", err)
 	}
 
+	<-doneCh
 	log.Println("we are returning from ws handler.")
 }
 


### PR DESCRIPTION
This change fixes a persistent issue running natty from the scoir/scoir
repo where memory usage grew unbounded. This issue causes unexpected pod
eviction events within Kubernetes. The downstream impact is that clients
websocket connections would experience intermittent 502 issues.

Closes: OPS-200
TODO: OPS-214