### PR TITLE
use reader composition to avoid massive memory allocation per connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/scoir/nats-websocket-gw
 
 go 1.22
 
-require github.com/gorilla/websocket v1.5.0
+require (
+	github.com/google/go-cmp v0.6.0
+	github.com/gorilla/websocket v1.5.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/scoir/nats-websocket-gw
 
-go 1.18
+go 1.22
 
 require github.com/gorilla/websocket v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/internal/buffer/prefixer.go
+++ b/internal/buffer/prefixer.go
@@ -1,0 +1,27 @@
+package buffer
+
+import (
+	"bytes"
+	"io"
+)
+
+func CopyCommandWithPrefix(prefix string, dst io.Writer, src io.Reader) (int64, error) {
+	// Tee out the first 4 bytes to check if it's a SUB command
+	cmdBuffer := bytes.NewBuffer(make([]byte, 0, 4))
+	cmdTeeReader := io.TeeReader(io.LimitReader(src, 4), cmdBuffer)
+	cmdLen, err := io.Copy(dst, cmdTeeReader)
+	if err != nil {
+		return 0, err
+	}
+	prefixLen := 0
+	if bytes.HasPrefix(cmdBuffer.Bytes(), []byte("SUB ")) {
+		// write in the prefix so that the websocket can't subscribe to anything but the prefix
+		prefixLen, err = dst.Write([]byte(prefix))
+		if err != nil {
+			return 0, err
+		}
+	}
+	// Copy the rest of the message
+	finalLen, _ := io.Copy(dst, src)
+	return cmdLen + int64(prefixLen) + finalLen, err
+}

--- a/internal/buffer/prefixer_test.go
+++ b/internal/buffer/prefixer_test.go
@@ -1,0 +1,43 @@
+package buffer_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/scoir/nats-websocket-gw/internal/buffer"
+)
+
+func TestWebsocketPrefixing(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "non-sub command is untouched", input: "PING", expected: "PING"},
+		{name: "sub command gets prefixed", input: "SUB abc.xyz 2", expected: "SUB prefixed.abc.xyz 2"},
+		{name: "sub command with multiple spaces gets prefixed", input: "SUB      abc.xyz 2", expected: "SUB prefixed.     abc.xyz 2"},
+		{name: "unrelated command with sub prefix is untouched", input: "SUBTRACT", expected: "SUBTRACT"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := bytes.NewReader([]byte(tc.input))
+			w := bytes.NewBuffer(nil)
+
+			count, err := buffer.CopyCommandWithPrefix("prefixed.", w, r)
+			actual := w.Bytes()
+			if err != nil {
+				t.Fatalf("unexpected error: %e", err)
+			}
+			diff := cmp.Diff(string(actual), tc.expected)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+			if count != int64(len(tc.expected)) {
+				t.Fatalf("expected count %d, got %d", len(tc.expected), count)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When we introduced prefixing, we built on top of the Trace memory allocation for some reason.  This means that for each websocket connection, a byte array of 1024*1024 is allocated.  That seems drastic for the normal use case of simple SUB commands and PINGs.

This attempts to allocate nothing up front and only allocate 4 bytes on each read to check the first 4 characters for a SUB command.